### PR TITLE
adds make:seeder to canvas command

### DIFF
--- a/canvas
+++ b/canvas
@@ -36,6 +36,7 @@ $app->add(new Orchestra\Canvas\Commands\Database\Eloquent($preset));
 $app->add(new Orchestra\Canvas\Commands\Database\Factory($preset));
 $app->add(new Orchestra\Canvas\Commands\Database\Migration($preset));
 $app->add(new Orchestra\Canvas\Commands\Database\Observer($preset));
+$app->add(new Orchestra\Canvas\Commands\Database\Seeder($preset));
 $app->add(new Orchestra\Canvas\Commands\Job($preset));
 $app->add(new Orchestra\Canvas\Commands\Listener($preset));
 $app->add(new Orchestra\Canvas\Commands\Mail($preset));


### PR DESCRIPTION
This adds the `make:seeder` command available during package development when calling `./vendor/bin/canvas make:seeder ...` which currently fails because it is not defined.

The tests pass because they are not using this file to run commands.