### PR TITLE
Add code branch for pest option on `make:test` command

### DIFF
--- a/src/Commands/Testing.php
+++ b/src/Commands/Testing.php
@@ -59,9 +59,12 @@ class Testing extends Generator
      */
     public function getStubFileName(): string
     {
+        $prefix = $this->option('pest')
+            ? 'pest'
+            : 'test';
         return $this->option('unit')
-            ? 'test.unit.stub'
-            : 'test.stub';
+            ? "$prefix.unit.stub"
+            : "$prefix.stub";
     }
 
     /**

--- a/tests/Feature/Generators/TestingTest.php
+++ b/tests/Feature/Generators/TestingTest.php
@@ -127,4 +127,110 @@ class TestingTest extends TestCase
             'class FooTest extends FeatureTestCase',
         ], 'tests/Feature/FooTest.php');
     }
+
+    public function it_can_generate_pest_feature_test_file()
+    {
+        $this->artisan('make:test', ['name' => 'FooTest', '--pest' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            '$response = $this->get(\'/\');',
+            '$response->assertStatus(200);'
+        ], 'tests/Feature/FooTest.php');
+    }
+
+    /** @test */
+    public function it_can_generate_pest_unit_test_file()
+    {
+        $this->artisan('make:test', ['name' => 'FooTest', '--unit' => true, '--pest' => true])
+            ->assertExitCode(0);
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            'expect(true)->toBeTrue();',
+        ], 'tests/Unit/FooTest.php');
+    }
+
+    /** @test */
+    public function it_can_generate_pest_unit_test_file_on_laravel_preset_with_different_testcase()
+    {
+        $this->instance('orchestra.canvas', new Laravel(
+            ['namespace' => 'App', 'testing' => ['namespace' => 'Tests', 'extends' => ['unit' => 'Tests\UnitTestCase']]], $this->app->basePath(), $this->filesystem
+        ));
+
+        $this->artisan('make:test', ['name' => 'FooTest', '--unit' => true, '--pest' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            'expect(true)->toBeTrue();',
+        ], 'tests/Unit/FooTest.php');
+    }
+
+    /** @test */
+    public function it_can_generate_pest_feature_test_file_on_laravel_preset_with_different_testcase()
+    {
+        $this->instance('orchestra.canvas', new Laravel(
+            ['namespace' => 'App', 'testing' => ['namespace' => 'Tests', 'extends' => ['feature' => 'Tests\FeatureTestCase']]], $this->app->basePath(), $this->filesystem
+        ));
+
+        $this->artisan('make:test', ['name' => 'FooTest', '--pest' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            '$response = $this->get(\'/\');',
+            '$response->assertStatus(200);'
+        ], 'tests/Feature/FooTest.php');
+    }
+
+    /** @test */
+    public function it_can_generate_pest_feature_test_file_on_package_preset()
+    {
+        $this->instance('orchestra.canvas', new Package(
+            ['namespace' => 'Foo', 'testing' => ['namespace' => 'Foo\Tests']], $this->app->basePath(), $this->filesystem
+        ));
+
+        $this->artisan('make:test', ['name' => 'FooTest', '--pest' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            '$response = $this->get(\'/\');',
+            '$response->assertStatus(200);'
+        ], 'tests/Feature/FooTest.php');
+    }
+
+    /** @test */
+    public function it_can_generate_pest_unit_test_file_on_package_preset_with_different_testcase()
+    {
+        $this->instance('orchestra.canvas', new Package(
+            ['namespace' => 'Foo', 'testing' => ['namespace' => 'Foo\Tests', 'extends' => ['unit' => 'Foo\Tests\UnitTestCase']]], $this->app->basePath(), $this->filesystem
+        ));
+
+        $this->artisan('make:test', ['name' => 'FooTest', '--unit' => true, '--pest' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            'expect(true)->toBeTrue();',
+        ], 'tests/Unit/FooTest.php');
+    }
+
+    /** @test */
+    public function it_can_generate_pest_feature_test_file_on_package_preset_with_different_testcase()
+    {
+        $this->instance('orchestra.canvas', new Package(
+            ['namespace' => 'Foo', 'testing' => ['namespace' => 'Foo\Tests', 'extends' => ['feature' => 'Foo\Tests\FeatureTestCase']]], $this->app->basePath(), $this->filesystem
+        ));
+
+        $this->artisan('make:test', ['name' => 'FooTest', '--pest' => true])
+            ->assertExitCode(0);
+
+        $this->assertFileContains([
+            'test(\'example\', function () {',
+            '$response = $this->get(\'/\');',
+            '$response->assertStatus(200);'
+        ], 'tests/Feature/FooTest.php');
+    }
 }


### PR DESCRIPTION
- Stubs already existed, but the option was ignored
- Includes supporting tests

Resolves #19 