### PR TITLE
Improvement/documentation correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Which can be execute via:
 
 With **Canvas**, you can run the equivalent command via:
 
-    composer exec canvas make:migration CreatePostsTable --create
+    composer exec canvas make:migration CreatePostsTable -- --create
 
 ### `canvas.yaml` Preset file
 

--- a/README.md
+++ b/README.md
@@ -23,29 +23,29 @@ To install through composer, run the following command from terminal:
 
 As a Laravel developer, you should be familiar with the following commands:
 
-| Command.            | Description
-|:--------------------|:---------------------     
-| `make:channel` | Create a new channel class
-| `make:command` | Create a new Artisan command
-| `make:controller` | Create a new controller class
-| `make:event` | Create a new event class
-| `make:exception` | Create a new custom exception class
-| `make:factory` | Create a new model factory
-| `make:job` | Create a new job class
-| `make:listener` | Create a new event listener class
-| `make:mail` | Create a new email class
-| `make:middleware` | Create a new middleware class
-| `make:migration` | Create a new migration file
-| `make:model` | Create a new Eloquent model class
-| `make:notification` | Create a new notification class
-| `make:observer` | Create a new observer class
-| `make:policy` | Create a new policy class
-| `make:provider` | Create a new service provider class
-| `make:request` | Create a new form request class
-| `make:resource` | Create a new resource
-| `make:rule` | Create a new validation rule
-| `make:seeder` | Create a new seeder class
-| `make:test` | Create a new test class
+| Command.            | Description                         |
+|:--------------------|:------------------------------------|
+| `make:channel`      | Create a new channel class          |
+| `make:command`      | Create a new Artisan command        |
+| `make:controller`   | Create a new controller class       |
+| `make:event`        | Create a new event class            |
+| `make:exception`    | Create a new custom exception class |
+| `make:factory`      | Create a new model factory          |
+| `make:job`          | Create a new job class              |
+| `make:listener`     | Create a new event listener class   |
+| `make:mail`         | Create a new email class            |
+| `make:middleware`   | Create a new middleware class       |
+| `make:migration`    | Create a new migration file         |
+| `make:model`        | Create a new Eloquent model class   |
+| `make:notification` | Create a new notification class     |
+| `make:observer`     | Create a new observer class         |
+| `make:policy`       | Create a new policy class           |
+| `make:provider`     | Create a new service provider class |
+| `make:request`      | Create a new form request class     |
+| `make:resource`     | Create a new resource               |
+| `make:rule`         | Create a new validation rule        |
+| `make:seeder`       | Create a new seeder class           |
+| `make:test`         | Create a new test class             |
 
 Which can be execute via:
 


### PR DESCRIPTION
### Fixed minor issue with documentation surrounding `composer exec` syntax with options.

When calling a binary or script with Composer, to pass command line arguments, you must also pass a blank option (`--`) to inform Composer to pass the arguments through.

See:
- `composer exec --help`
- https://getcomposer.org/doc/articles/scripts.md#running-scripts-manually (Not `exec`, but approaches arguments the same way.

### Updated commands table in README.md to be more compatible

For compatibility reasons, the pipe character preceding and following each table row. GitHub's markdown renderer doesn't care, but some editors/parsers could render this incorrectly.

See: https://www.markdownguide.org/extended-syntax/#tables