### PR TITLE
Fixes `preset` command usage

### DIFF
--- a/src/Console/PresetMakeCommand.php
+++ b/src/Console/PresetMakeCommand.php
@@ -60,7 +60,7 @@ class PresetMakeCommand extends GeneratorCommand
             return $namespace;
         }
 
-        switch ($this->option('name')) {
+        switch ($this->argument('name')) {
             case 'package':
                 return 'PackageName';
             case 'laravel':


### PR DESCRIPTION
When using `vendor/bin/canvas preset laravel`, command from README, an error is generated.

This happens because `option` is used instead of the given `argument`.