### PR TITLE
Adds missing preset option

### DIFF
--- a/src/Console/ControllerMakeCommand.php
+++ b/src/Console/ControllerMakeCommand.php
@@ -139,4 +139,31 @@ class ControllerMakeCommand extends \Illuminate\Routing\Console\ControllerMakeCo
     {
         return $this->possibleModelsUsingCanvas();
     }
+
+    /**
+     * Generate the form requests for the given model and classes.
+     *
+     * @param  string  $modelClass
+     * @param  string  $storeRequestClass
+     * @param  string  $updateRequestClass
+     * @return array
+     */
+    protected function generateFormRequests($modelClass, $storeRequestClass, $updateRequestClass)
+    {
+        $storeRequestClass = 'Store'.class_basename($modelClass).'Request';
+
+        $this->call('make:request', [
+            'name' => $storeRequestClass,
+            '--preset' => $this->option('preset'),
+        ]);
+
+        $updateRequestClass = 'Update'.class_basename($modelClass).'Request';
+
+        $this->call('make:request', [
+            'name' => $updateRequestClass,
+            '--preset' => $this->option('preset'),
+        ]);
+
+        return [$storeRequestClass, $updateRequestClass];
+    }
 }

--- a/src/Console/ModelMakeCommand.php
+++ b/src/Console/ModelMakeCommand.php
@@ -87,6 +87,7 @@ class ModelMakeCommand extends \Illuminate\Foundation\Console\ModelMakeCommand
         $this->call('make:factory', [
             'name' => "{$factory}Factory",
             '--model' => $this->qualifyClass($this->getNameInput()),
+            '--preset' => $this->option('preset'),
         ]);
     }
 


### PR DESCRIPTION
Uses preset option when:

- Generating factory from `make:model`.
- Generating requests from `make:controller`.