### PR TITLE
[10.x] Remove override of the possibleModels() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,23 +32,26 @@
         "php": "^8.2",
         "composer-runtime-api": "^2.2",
         "composer/semver": "^3.0",
-        "illuminate/console": "^12.14.0",
-        "illuminate/database": "^12.14.0",
-        "illuminate/filesystem": "^12.14.0",
-        "illuminate/support": "^12.14.0",
-        "orchestra/canvas-core": "^10.0.1",
+        "illuminate/console": "^12.38.0",
+        "illuminate/database": "^12.38.0",
+        "illuminate/filesystem": "^12.38.0",
+        "illuminate/support": "^12.38.0",
+        "orchestra/canvas-core": "^10.1.0",
         "orchestra/sidekick": "^1.2.0",
         "orchestra/testbench-core": "^10.2.1",
         "symfony/polyfill-php83": "^1.32",
         "symfony/yaml": "^7.2.0"
     },
     "require-dev": {
-        "laravel/framework": "^12.14.0",
+        "laravel/framework": "^12.38.0",
         "laravel/pint": "^1.24",
         "mockery/mockery": "^1.6.12",
         "phpstan/phpstan": "^2.1.14",
         "phpunit/phpunit": "^11.5.18",
         "spatie/laravel-ray": "^1.40.2"
+    },
+    "conflict": {
+        "laravel/framework": "<12.38.0|>=13.0.0"
     },
     "config": {
         "preferred-install": {

--- a/src/Console/ControllerMakeCommand.php
+++ b/src/Console/ControllerMakeCommand.php
@@ -146,6 +146,17 @@ class ControllerMakeCommand extends \Illuminate\Routing\Console\ControllerMakeCo
     }
 
     /**
+     * Get a list of possible model names.
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    protected function findAvailableModels()
+    {
+        return $this->findAvailableModelsUsingCanvas();
+    }
+
+    /**
      * Generate the form requests for the given model and classes.
      *
      * @param  string  $modelClass

--- a/src/Console/ControllerMakeCommand.php
+++ b/src/Console/ControllerMakeCommand.php
@@ -146,17 +146,6 @@ class ControllerMakeCommand extends \Illuminate\Routing\Console\ControllerMakeCo
     }
 
     /**
-     * Get a list of possible model names.
-     *
-     * @return array<int, string>
-     */
-    #[\Override]
-    protected function possibleModels()
-    {
-        return $this->possibleModelsUsingCanvas();
-    }
-
-    /**
      * Generate the form requests for the given model and classes.
      *
      * @param  string  $modelClass

--- a/src/Console/ObserverMakeCommand.php
+++ b/src/Console/ObserverMakeCommand.php
@@ -75,15 +75,4 @@ class ObserverMakeCommand extends \Illuminate\Foundation\Console\ObserverMakeCom
     {
         return $this->rootNamespaceUsingCanvas();
     }
-
-    /**
-     * Get a list of possible model names.
-     *
-     * @return array<int, string>
-     */
-    #[\Override]
-    protected function possibleModels()
-    {
-        return $this->possibleModelsUsingCanvas();
-    }
 }

--- a/src/Console/ObserverMakeCommand.php
+++ b/src/Console/ObserverMakeCommand.php
@@ -75,4 +75,15 @@ class ObserverMakeCommand extends \Illuminate\Foundation\Console\ObserverMakeCom
     {
         return $this->rootNamespaceUsingCanvas();
     }
+
+    /**
+     * Get a list of possible model names.
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    protected function findAvailableModels()
+    {
+        return $this->findAvailableModelsUsingCanvas();
+    }
 }

--- a/src/Console/PolicyMakeCommand.php
+++ b/src/Console/PolicyMakeCommand.php
@@ -89,4 +89,15 @@ class PolicyMakeCommand extends \Illuminate\Foundation\Console\PolicyMakeCommand
 
         return $this->userProviderModelUsingCanvas($guard);
     }
+
+    /**
+     * Get a list of possible model names.
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    protected function findAvailableModels()
+    {
+        return $this->findAvailableModelsUsingCanvas();
+    }
 }

--- a/src/Console/PolicyMakeCommand.php
+++ b/src/Console/PolicyMakeCommand.php
@@ -89,15 +89,4 @@ class PolicyMakeCommand extends \Illuminate\Foundation\Console\PolicyMakeCommand
 
         return $this->userProviderModelUsingCanvas($guard);
     }
-
-    /**
-     * Get a list of possible model names.
-     *
-     * @return array<int, string>
-     */
-    #[\Override]
-    protected function possibleModels()
-    {
-        return $this->possibleModelsUsingCanvas();
-    }
 }


### PR DESCRIPTION
This PR fixes the Override of the `Illuminate\Console\GeneratorCommand` that was removed in Laravel 12.38 released on November 12, 2025 https://github.com/laravel/framework/compare/v12.37.0...v12.38.0 

Keeping as draft as this relies on another PR to be merged in `canavs-core`. PR to update Canvas Core https://github.com/orchestral/canvas-core/pull/15

Resolves [Issue #47](https://github.com/orchestral/canvas/issues/47)